### PR TITLE
Only use operator equals for reference types

### DIFF
--- a/src/Generator/Generators/CSharp/CSharpSources.cs
+++ b/src/Generator/Generators/CSharp/CSharpSources.cs
@@ -1011,7 +1011,7 @@ internal static bool {Helpers.TryGetNativeToManagedMappingIdentifier}(IntPtr nat
         {
             if (field.Type.IsClass() && !field.Type.IsPointer())
             {
-                if (field.Type.TryGetClass(out Class fieldClass) && !(fieldClass is ClassTemplateSpecialization))
+                if (field.Type.TryGetClass(out Class fieldClass) && !(fieldClass is ClassTemplateSpecialization) && !fieldClass.IsValueType)
                 {
                     var caop = fieldClass.Methods.FirstOrDefault(m => m.OperatorKind == CXXOperatorKind.Equal);
                     if (caop != null && caop.IsGenerated)


### PR DESCRIPTION
This operator equals branch here was added by us at some point but it wasn't made with value types in mind. This PR adds a check to only use this generation branch for non-value types.

Value types now just use CppSharp's default setter.