### PR TITLE
Revert only use operator equals when explicitly generated 

### DIFF
--- a/src/Generator/Generators/CSharp/CSharpSources.cs
+++ b/src/Generator/Generators/CSharp/CSharpSources.cs
@@ -1016,7 +1016,7 @@ internal static bool {Helpers.TryGetNativeToManagedMappingIdentifier}(IntPtr nat
                     if (field.Type.TryGetClass(out Class fieldClass) && !(fieldClass is ClassTemplateSpecialization) && !fieldClass.IsValueType)
                     {
                         var caop = fieldClass.Methods.FirstOrDefault(m => m.OperatorKind == CXXOperatorKind.Equal);
-                        if (caop != null && caop.IsExplicitlyGenerated)
+                        if (caop != null && caop.IsGenerated)
                         {
                             var fieldName = ((Class)field.Namespace).Layout.Fields.First(
                                 f => f.FieldPtr == field.OriginalPtr).Name;


### PR DESCRIPTION
This reverts commit b54eabade7bb5732c039e6ec2a22c806b042ca7f.

It seems no classes actually had explicitly generated equals operators which was causing other bugs.